### PR TITLE
Fixed ResqueScheduler:: nextDelayedTimestamp call to zrangebyscore

### DIFF
--- a/lib/ResqueScheduler/ResqueScheduler.php
+++ b/lib/ResqueScheduler/ResqueScheduler.php
@@ -245,7 +245,7 @@ class ResqueScheduler
             $at = self::getTimestamp($at);
         }
 
-        $items = \Resque::redis()->zrangebyscore(self::QUEUE_NAME, '-inf', $at, array('limit', 0, 1));
+        $items = \Resque::redis()->zrangebyscore(self::QUEUE_NAME, '-inf', $at, 'LIMIT', 0, 1);
         if (!empty($items)) {
             return $items[0];
         }

--- a/lib/ResqueScheduler/ResqueScheduler.php
+++ b/lib/ResqueScheduler/ResqueScheduler.php
@@ -245,7 +245,11 @@ class ResqueScheduler
             $at = self::getTimestamp($at);
         }
 
-        $items = \Resque::redis()->zrangebyscore(self::QUEUE_NAME, '-inf', $at, 'LIMIT', 0, 1);
+        if (class_exists('Redis')) {
+            $items = \Resque::redis()->zrangebyscore(self::QUEUE_NAME, '-inf', $at, array('limit' => array(0, 1)));
+        } else {
+            $items = \Resque::redis()->zrangebyscore(self::QUEUE_NAME, '-inf', $at, 'limit', 0, 1);
+        }
         if (!empty($items)) {
             return $items[0];
         }


### PR DESCRIPTION
When using PHP's `Redis` class, the method signature for `Redis:: zrangebyscore` is different than when using the `Redisent` client.